### PR TITLE
Remove empty values

### DIFF
--- a/nodejs/Chart.yaml
+++ b/nodejs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for HMCTS nodejs apps
 name: nodejs
-version: 0.0.11
+version: 0.0.12
 keywords:
 - node
 - javascript

--- a/nodejs/values.yaml
+++ b/nodejs/values.yaml
@@ -2,8 +2,6 @@ applicationPort: 3000
 registerAdditionalDns:
   enabled: false
 image: hmctssandbox.azurecr.io/hmcts/chart-nodejs-testapp
-environment:
-configmap:
 memoryRequests: 64Mi
 cpuRequests: 25m
 memoryLimits: 512Mi


### PR DESCRIPTION
As they cause errors when overridden. From jenkins logs:

13:49:17 2019/01/30 13:49:16 warning: skipped value for environment: Not a table.
13:49:17 2019/01/30 13:49:16 warning: skipped value for environment: Not a table.
...