### PR TITLE
Adding Instrumentation Key as a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ nodejs:
       resourceGroup: rpe-service-auth-provider
       secrets:
         - microservicekey-cmcLegalFrontend
+  applicationInsightsInstrumentKey: some-key
 ```
 
 ## Configuration
@@ -62,6 +63,8 @@ You most likely may override `image`, `applicationPort` and `environment` for yo
 | `livenessPeriod` | Liveness probe period (seconds) | `15` |
 | `livenessFailureThreshold`| Liveness failure threshold | `3` |
 | `keyVaults`| This section is about adding the keyvault secrets to the file system see [Adding Azure Key Vault Secrets]()| none |
+| `applicationInsightsInstrumentKey` | Instrumentation Key for App Insights , It is mapped to `APPINSIGHTS_INSTRUMENTATIONKEY` as environment variable | `00000000-0000-0000-0000-000000000000`
+
 
 ## Adding Azure Key Vault Secrets
 Key vault secrets are mounted to the container filesystem using what's called a [flexvolume](https://github.com/Azure/kubernetes-keyvault-flexvol)

--- a/nodejs/Chart.yaml
+++ b/nodejs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for HMCTS nodejs apps
 name: nodejs
-version: 0.1.1
+version: 0.1.2
 keywords:
 - node
 - javascript

--- a/nodejs/templates/deployment.yaml
+++ b/nodejs/templates/deployment.yaml
@@ -20,6 +20,8 @@ spec:
         name: {{ template "hmcts.releaseName" . }}
         {{- if .Values.environment }}
         env:
+        - name: APPINSIGHTS_INSTRUMENTATIONKEY
+          value: {{ .Values.applicationInsightsInstrumentKey | quote }}
           {{- range $key, $val := .Values.environment }}
         - name: {{ $key }}
           value: {{ $val | quote }}

--- a/nodejs/templates/deployment.yaml
+++ b/nodejs/templates/deployment.yaml
@@ -18,7 +18,6 @@ spec:
       containers:
       - image: {{ required "An image must be supplied to the chart" .Values.image }}
         name: {{ template "hmcts.releaseName" . }}
-        {{- if .Values.environment }}
         env:
         - name: APPINSIGHTS_INSTRUMENTATIONKEY
           value: {{ .Values.applicationInsightsInstrumentKey | quote }}
@@ -26,7 +25,6 @@ spec:
         - name: {{ $key }}
           value: {{ $val | quote }}
           {{- end}}
-        {{- end }}
         {{- if .Values.configmap }}
         envFrom:
           - configMapRef:

--- a/nodejs/values.yaml
+++ b/nodejs/values.yaml
@@ -15,3 +15,4 @@ livenessDelay: 5
 livenessTimeout: 3
 livenessPeriod: 15
 livenessFailureThreshold: 3
+applicationInsightsInstrumentKey: '00000000-0000-0000-0000-000000000000'


### PR DESCRIPTION
Adding Instrumentation Key as a variable

### JIRA link ###
 https://tools.hmcts.net/jira/browse/RPE-879 (Though directly not associated) 

### Change description ###

Added Instrumentation Key for App Insights . 
Variable is mapped to APPINSIGHTS_INSTRUMENTATIONKEY as per [applicationInsights package](https://www.npmjs.com/package/applicationinsights) so that apps can just call .setup().

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
