### PR TITLE
Adding Pod Disruption Budgets for NodeJs Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ You most likely may override `image`, `applicationPort` and `environment` for yo
 | `livenessFailureThreshold`| Liveness failure threshold | `3` |
 | `keyVaults`| This section is about adding the keyvault secrets to the file system see [Adding Azure Key Vault Secrets]()| none |
 | `applicationInsightsInstrumentKey` | Instrumentation Key for App Insights , It is mapped to `APPINSIGHTS_INSTRUMENTATIONKEY` as environment variable | `00000000-0000-0000-0000-000000000000` |
+| `pdb.enabled` | To enable PodDisruptionBudget on the pods for handling disruptions | `true` |
+| `pdb.maxUnavailable` |  To configure the number of pods from the set that can be unavailable after the eviction. It can be either an absolute number or a percentage. pdb.minAvailable takes precedence over this if not nil | `50%` means evictions are allowed as long as no more than 50% of the desired replicas are unhealthy. It will allow disruption if you have only 1 replica.|
+| `pdb.minAvailable` |  To configure the number of pods from that set that must still be available after the eviction, even in the absence of the evicted pod. minAvailable can be either an absolute number or a percentage. This takes precedence over pdb.maxUnavailable if not nil. | `nil`|
 
 ## Adding Azure Key Vault Secrets
 Key vault secrets are mounted to the container filesystem using what's called a [flexvolume](https://github.com/Azure/kubernetes-keyvault-flexvol)

--- a/nodejs/Chart.yaml
+++ b/nodejs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for HMCTS nodejs apps
 name: nodejs
-version: 1.0.0
+version: 1.0.1
 keywords:
 - node
 - javascript

--- a/nodejs/templates/pdb.yaml
+++ b/nodejs/templates/pdb.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.pdb.enabled }}
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name:  {{ template "hmcts.releaseName" . }}
+spec:
+  {{ if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- else -}}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "hmcts.releaseName" . }}
+{{- end }}

--- a/nodejs/values.yaml
+++ b/nodejs/values.yaml
@@ -18,3 +18,6 @@ livenessPeriod: 15
 livenessFailureThreshold: 3
 applicationInsightsInstrumentKey: '00000000-0000-0000-0000-000000000000'
 imagePullPolicy: IfNotPresent
+pdb:
+  enabled: true
+  maxUnavailable: 50%


### PR DESCRIPTION
Adding Pod Disruption Budgets for NodeJs Chart

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-1014

### Change description ###

Adding Pod Disruption Budgets for NodeJs Chart

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
