### PR TITLE
remove subscription id and resource group for keyvaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,10 @@ nodejs:
     VAR_B: VALUE_B  
   keyVaults:
     cmc:
-      resourceGroup: cmc
       secrets:
         - smoke-test-citizen-username
         - smoke-test-ushmmer-password
     s2s:
-      resourceGroup: rpe-service-auth-provider
       secrets:
         - microservicekey-cmcLegalFrontend
   applicationInsightsInstrumentKey: some-key
@@ -91,19 +89,16 @@ To do this we need to add the **keyVaults** member to the configuration as below
 keyVaults:
     <VAULT_NAME>:
       excludeEnvironmentSuffix: true
-      resourceGroup: <VAULT_RESOURCE_GROUP>
       secrets:
         - <SECRET_NAME>
         - <SECRET_NAME2>
     <VAULT_NAME_2>:
-      resourceGroup: <VAULT_RESOURCE_GROUP_2>
       secrets:
         - <SECRET_NAME>
         - <SECRET_NAME2>
 ```
 **Where**:
 - *<VAULT_NAME>*: This is the name of the vault to access without the environment tag i.e. `s2s` or `bulkscan`.
-- *<VAULT_RESOURCE_GROUP>*: This is the resource group for the vault this also does not need the environment tag ie. for s2s vault it is `rpe-service-auth-provider`.
 - *<SECRET_NAME>* This is the name of the secret as it is in the vault. Note this is case and punctuation sensitive. i.e. in s2s there is the `microservicekey-cmcLegalFrontend` secret.
 - *excludeEnvironmentSuffix*: This is used for the global key vaults where there is not environment suffix ( e.g `-aat` ) required. It defaults to false if it is not there and should only be added if you are using a global key-vault.
 

--- a/ci-values.yaml
+++ b/ci-values.yaml
@@ -1,5 +1,4 @@
 global:
-  subscriptionId: "1c4f0704-a29e-403d-b719-b90c34ef14c9"
   tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
   environment: aat
   enableKeyVaults: true
@@ -20,12 +19,10 @@ configmap:
 keyVaults:
   bulk-scan:
     excludeEnvironmentSuffix: false
-    resourceGroup: bulk-scan
     secrets:
       - idam-client-secret
       - s2s-secret
   s2s:
-    resourceGroup: rpe-service-auth-provider
     secrets:
       - microservicekey-ccd-admin
       - microservicekey-ccd-data

--- a/nodejs/Chart.yaml
+++ b/nodejs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for HMCTS nodejs apps
 name: nodejs
-version: 1.6.0
+version: 1.7.0
 keywords:
 - node
 - javascript

--- a/nodejs/templates/_helpers.tpl
+++ b/nodejs/templates/_helpers.tpl
@@ -61,10 +61,8 @@ volumes:
     {{- end}}
     options:
       usepodidentity: "{{ if $aadIdentityName }}true{{ else }}false{{ end}}"
-      subscriptionid: {{ $globals.subscriptionId | quote }}
       tenantid: {{ $globals.tenantId | quote }}
       keyvaultname: "{{ $vault }}{{ if not (default $info.excludeEnvironmentSuffix false) }}-{{ $globals.environment }}{{ end }}"
-      resourcegroup: "{{ required " .keyVaults.VAULT requires a .resourceGroup" $info.resourceGroup  }}{{ if not (default $info.excludeEnvironmentSuffix false) }}-{{ $globals.environment }}{{ end }}"
       keyvaultobjectnames: "{{range $index, $secret := $info.secrets }}{{if $index}};{{end}}{{ $secret }}{{ end }}"
       keyvaultobjecttypes: "{{range $index, $secret := $info.secrets }}{{if $index}};{{end}}secret{{ end }}"
 {{- end }}


### PR DESCRIPTION


See https://github.com/Azure/kubernetes-keyvault-flexvol/pull/128 for background

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
