### PR TITLE
Make ingress class configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ You most likely may override `image`, `applicationPort` and `environment` for yo
 | `aadIdentityName` | Identity to assign to the pod, can be used for accessing azure resources such as key vault | `nil` |
 | `prometheus.enabled` | Whether to add an annotation to the deployment to say scrape prometheus metrics | `false` |
 | `prometheus.path` | Path for prometheus metrics | `/metrics` |
+| `ingressClass` | Ingress class | `traefik` |
 
 ## Adding Azure Key Vault Secrets
 Key vault secrets are mounted to the container filesystem using what's called a [flexvolume](https://github.com/Azure/kubernetes-keyvault-flexvol)

--- a/nodejs/Chart.yaml
+++ b/nodejs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for HMCTS nodejs apps
 name: nodejs
-version: 1.7.0
+version: 1.8.0
 keywords:
 - node
 - javascript

--- a/nodejs/templates/ingress.yaml
+++ b/nodejs/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- ( include "labels" . ) | indent 4 }}
   annotations:
-    kubernetes.io/ingress.class: traefik
+    kubernetes.io/ingress.class: {{ .Values.ingressClass }}
 spec:
   rules:
   {{- if .Values.ingressHost }}

--- a/nodejs/values.yaml
+++ b/nodejs/values.yaml
@@ -26,3 +26,4 @@ global:
 prometheus:
   enabled: false
   path: /metrics
+ingressClass: traefik


### PR DESCRIPTION
Required for hmcts demo for applications that don't support  oauth_proxy
and likely will be required for frontend apps going live.