### PR TITLE
DTSPO-2201 Add startup probes and upgrade chart-library to 0.6.3

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -17,10 +17,14 @@ resources:
     name: hmcts/cnp-azuredevops-libraries
     endpoint: hmcts
 
+variables:
+  - name: agentPool
+    value: ubuntu-latest
+
 jobs:
 - job: Validate
   pool:
-    vmImage: Ubuntu 16.04
+    vmImage: ${{ variables.agentPool }}
   steps:
   - template: steps/charts/validate.yaml@cnp-library
     parameters:
@@ -38,7 +42,7 @@ jobs:
       )
   dependsOn: Validate
   pool:
-    vmImage: Ubuntu 16.04
+    vmImage: ${{ variables.agentPool }}
   steps:
   - template: steps/charts/release.yaml@cnp-library
     parameters:
@@ -46,4 +50,3 @@ jobs:
       chartName: nodejs
       chartReleaseName: chart-nodejs
 
-      

--- a/nodejs/Chart.yaml
+++ b/nodejs/Chart.yaml
@@ -14,5 +14,5 @@ sources:
 icon: https://nodejs.org/static/images/logos/nodejs-new-pantone-black.png
 dependencies:
   - name: library
-    version: 0.6.2
+    version: 0.6.3
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/

--- a/nodejs/values.yaml
+++ b/nodejs/values.yaml
@@ -12,11 +12,11 @@ devcpuRequests: 25m
 devmemoryLimits: 512Mi
 devcpuLimits: 500m
 readinessPath: /health/readiness
-readinessDelay: 5
+readinessDelay: 0
 readinessTimeout: 3
 readinessPeriod: 15
 livenessPath: /health/liveness
-livenessDelay: 5
+livenessDelay: 0
 livenessTimeout: 3
 livenessPeriod: 15
 livenessFailureThreshold: 3

--- a/nodejs/values.yaml
+++ b/nodejs/values.yaml
@@ -20,6 +20,11 @@ livenessDelay: 5
 livenessTimeout: 3
 livenessPeriod: 15
 livenessFailureThreshold: 3
+startupPath: '/health/liveness'
+startupDelay: 5
+startupTimeout: 3
+startupPeriod: 10
+startupFailureThreshold: 3
 saEnabled: true
 devApplicationInsightsInstrumentKeyName: APPINSIGHTS_INSTRUMENTATIONKEY
 devApplicationInsightsInstrumentKey: '00000000-0000-0000-0000-000000000000'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-2201


### Change description ###
Upgrade chart-library version to 0.6.3
Added startup probe values - introduced in chart-library 0.6.3
Updated pipeline pool agent to use ubuntu-latest


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
