### PR TITLE
Dtspo 23130

### DIFF
--- a/nodejs/Chart.yaml
+++ b/nodejs/Chart.yaml
@@ -15,4 +15,4 @@ icon: https://nodejs.org/static/images/logos/nodejs-new-pantone-black.png
 dependencies:
   - name: library
     version: 2.2.2
-    repository: oci://hmctspublic.azurecr.io/helm/
+    repository: oci://hmctspublic.azurecr.io/helm

--- a/nodejs/Chart.yaml
+++ b/nodejs/Chart.yaml
@@ -15,4 +15,4 @@ icon: https://nodejs.org/static/images/logos/nodejs-new-pantone-black.png
 dependencies:
   - name: library
     version: 2.2.2
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    repository: oci://hmctspublic.azurecr.io/helm/


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-23130

### Change description

Updating Chart library reference to point at the new OCI endpoint as part of the upgrade work for DTSPO-23130.
All base charts will need an update as part of this work.

The new release off the back of this PR will also move chart-nodejs to the OCI endpoint.

### Testing done

Tested using this [PR](https://github.com/hmcts/cnp-plum-recipes-service/pull/1118) on the cnp-plum-recipe-service repo and pipeline.
Build successfully went green with the changes in this PR using the [pre-release](https://github.com/hmcts/chart-java/releases/tag/v5.3.0-beta) for chart java v5.3.0-beta

The same changes are being made here but I am referencing the chart-java as the pipeline for testing nodejs was flakey.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
