### PR TITLE
Remove helm-requirements from renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,15 +1,5 @@
 {
-  "enabledManagers": [
-    "helm-requirements"
-  ],
-  "helm-requirements": {
-    "fileMatch": [
-      "\\Chart.yaml|requirements.yaml$"
-    ],
-    "aliases": {
-      "hmctspublic": "https://hmctspublic.azurecr.io/helm/v1/repo/"
-    }
-  },
+  "enabledManagers": [],
   "extends": [
     "local>hmcts/.github:renovate-config"
   ]

--- a/.github/renovate.json.bak
+++ b/.github/renovate.json.bak
@@ -1,0 +1,16 @@
+{
+  "enabledManagers": [
+    "helm-requirements"
+  ],
+  "helm-requirements": {
+    "fileMatch": [
+      "\\Chart.yaml|requirements.yaml$"
+    ],
+    "aliases": {
+      "hmctspublic": "https://hmctspublic.azurecr.io/helm/v1/repo/"
+    }
+  },
+  "extends": [
+    "local>hmcts/.github:renovate-config"
+  ]
+}


### PR DESCRIPTION
This PR removes the deprecated helm-requirements manager which is no longer needed. Please review and merge.